### PR TITLE
009 businesses endpoint

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -2,9 +2,6 @@ from rest_framework import serializers
 
 class BusinessSerializer(serializers.Serializer):
     camis = serializers.CharField()
-    dba = serializers.CharField(required=False)
-    boro = serializers.CharField(required=False)
-    street = serializers.CharField(required=False)
-    building = serializers.CharField(required=False)
-    zipcode = serializers.CharField(required=False)
-    cuisine_description = serializers.CharField(required=False)
+    dba = serializers.CharField(allow_blank=True)
+    address = serializers.CharField(allow_blank=True)
+    cuisine_description = serializers.CharField(allow_blank=True)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+class BusinessSerializer(serializers.Serializer):
+    camis = serializers.CharField()
+    dba = serializers.CharField(required=False)
+    boro = serializers.CharField(required=False)
+    street = serializers.CharField(required=False)
+    building = serializers.CharField(required=False)
+    zipcode = serializers.CharField(required=False)
+    cuisine_description = serializers.CharField(required=False)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,7 +3,9 @@ from rest_framework import routers
 from views import BusinessesViewSet
 
 router = routers.DefaultRouter()
+router.register(r'businesses', BusinessesViewSet, base_name='businesses')
 
 urlpatterns = [
     url(r'^', include(router.urls)),
 ]
+

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url, include
+from rest_framework import routers
+from views import BusinessesViewSet
+
+router = routers.DefaultRouter()
+
+urlpatterns = [
+    url(r'^', include(router.urls)),
+]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,8 +1,19 @@
-from django.shortcuts import render
-from rest_framework.viewsets import GenericViewSet
+from rest_framework import viewsets, mixins
+from serializers import BusinessSerializer
 
 from sodapy import Socrata
 
-# Create your views here.
-class BusinessesViewSet(GenericViewSet):
-    pass
+class BusinessesViewSet(mixins.ListModelMixin,
+                        viewsets.GenericViewSet):
+
+    serializer_class = BusinessSerializer
+
+    def get_queryset(self):
+        client = Socrata("data.cityofnewyork.us", "z9bHXnSMLOVBFTGrELvWCcCBN")
+        businesses = client.get("9w7m-hzhe", content_type="json",
+                                limit="500000",
+                                select="camis, dba, boro, building, street, zipcode, cuisine_description")
+        # Get all unique businesses
+        businesses = {v['camis']:v for v in businesses}.values()
+        return businesses
+

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,7 +1,15 @@
 from rest_framework import viewsets, mixins
 from serializers import BusinessSerializer
-
+from ickly import secret_settings
 from sodapy import Socrata
+
+class Business(object):
+    def __init__(self, camis, dba, cuisine_description, address):
+        self.camis = camis
+        self.dba = dba
+        self.cuisine_description = cuisine_description
+        self.address = address
+
 
 class BusinessesViewSet(mixins.ListModelMixin,
                         viewsets.GenericViewSet):
@@ -9,11 +17,20 @@ class BusinessesViewSet(mixins.ListModelMixin,
     serializer_class = BusinessSerializer
 
     def get_queryset(self):
-        client = Socrata("data.cityofnewyork.us", "z9bHXnSMLOVBFTGrELvWCcCBN")
-        businesses = client.get("9w7m-hzhe", content_type="json",
-                                limit="500000",
+        client = Socrata("data.cityofnewyork.us", secret_settings.APP_TOKEN)
+        businesses_data = client.get("9w7m-hzhe", content_type="json",
+                                limit="100",
                                 select="camis, dba, boro, building, street, zipcode, cuisine_description")
+
         # Get all unique businesses
-        businesses = {v['camis']:v for v in businesses}.values()
+        businesses_data = {v['camis']:v for v in businesses_data}.values()
+
+        businesses = [Business(camis=business.get('camis', ''),
+                                dba=business.get('dba', ''),
+                                cuisine_description=business.get('cuisine_description', ''),
+                                address=business.get('building', '') + ' ' +
+                                        business.get('street', '') + ' ' +
+                                        business.get('boro', '') + ' ' +
+                                        business.get('zipcode', '')) for business in businesses_data]
         return businesses
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,3 +1,8 @@
 from django.shortcuts import render
+from rest_framework.viewsets import GenericViewSet
+
+from sodapy import Socrata
 
 # Create your views here.
+class BusinessesViewSet(GenericViewSet):
+    pass

--- a/backend/ickly/settings.py
+++ b/backend/ickly/settings.py
@@ -53,6 +53,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'webpack_loader',
+    'rest_framework',
+
     'api',
 ]
 

--- a/backend/ickly/settings.py
+++ b/backend/ickly/settings.py
@@ -122,6 +122,10 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/

--- a/backend/ickly/urls.py
+++ b/backend/ickly/urls.py
@@ -13,11 +13,12 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.contrib import admin
 from django.views.generic import TemplateView
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='index.html')),
     url(r'^admin/', admin.site.urls),
+    url(r'^api/v1/', include('api.urls', namespace='api'))
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
 Django==1.10.1
 django-webpack-loader==0.3.3
 djangorestframework==3.4.6
+future==0.15.0
 psycopg2==2.6.2
+py==1.4.31
+pytest==2.8.7
+requests==2.7.0
+requests-mock==0.6.0
+six==1.9.0
+sodapy==1.4.0
+wheel==0.24.0
 wsgiref==0.1.2


### PR DESCRIPTION
This is what i have so far. 

In the `BusinessSerialzier` i added `required=False` on all of the fields (except for `camis` which is the equivalent of a unique id of a business in the dataset) to deal with the non existent values in the dataset. It works, but seems odd to do...

In the `BusinessesViewSet`'s `get_queryset` method, line 17 returns all of the unique businesses based on the `camis`, but this seems like a slow hackish way to do this. I originally tried to just include a `group by = 'camis'` in the call to the api, but this would break when there were any other missing values in the columns i was selecting. 

