### PR TITLE
052 frontend routes

### DIFF
--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import Navigation from './components/nav';
-import Header from './components/header';
-import BusinessSearch from './containers/businessSearch';
+import MainRouter from './components/mainRouter';
 
 const App = () => (
   <div>
+    <MainRouter />
     <Navigation />
-    <Header />
-    <BusinessSearch />
   </div>
 )
 

--- a/frontend/app/components/contact.jsx
+++ b/frontend/app/components/contact.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+class Contact extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <div className="row">
+          <div className="col-lg-12 text-center">
+            <h1>Contact</h1>
+                <ul className="list-unstyled">
+                  <li>things</li>
+                  <li>stuff</li>
+                </ul>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Contact;

--- a/frontend/app/components/home.jsx
+++ b/frontend/app/components/home.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Navigation from './nav';
+import Header from './header';
+import BusinessSearch from '../containers/businessSearch';
+
+const Home = () => (
+  <div>
+    <Header />
+    <BusinessSearch />
+  </div>
+)
+
+export default Home;

--- a/frontend/app/components/mainRouter.jsx
+++ b/frontend/app/components/mainRouter.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Route, Switch } from 'react-router-dom'
+import About from './about'
+import Home from './home'
+import Contact from './contact';
+
+const MainRouter = () => (
+  <main>
+    <Switch>
+      <Route exact path="/" component={Home}/>
+      <Route path="/about" component={About}/>
+      <Route path="/contact" component={Contact}/>
+     </Switch>
+  </main>
+)
+
+export default MainRouter;

--- a/frontend/app/components/nav.jsx
+++ b/frontend/app/components/nav.jsx
@@ -12,7 +12,9 @@ class Navigation extends React.Component {
       <Navbar inverse fixedTop collapseOnSelect>
         <Navbar.Header>
           <Navbar.Brand>
-            <a href="/">Ickly</a>
+            <LinkContainer to="/">
+              <a href="#">Ickly</a>
+            </LinkContainer>
           </Navbar.Brand>
           <Navbar.Toggle />
         </Navbar.Header>

--- a/frontend/app/components/nav.jsx
+++ b/frontend/app/components/nav.jsx
@@ -9,7 +9,7 @@ class Navigation extends React.Component {
 
   render() {
     return (
-      <Navbar inverse fixedTop >
+      <Navbar inverse fixedTop collapseOnSelect>
         <Navbar.Header>
           <Navbar.Brand>
             <a href="/">Ickly</a>

--- a/frontend/app/components/nav.jsx
+++ b/frontend/app/components/nav.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Navbar, Nav, NavItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class Navigation extends React.Component {
   constructor(props) {
@@ -11,14 +12,18 @@ class Navigation extends React.Component {
       <Navbar inverse fixedTop >
         <Navbar.Header>
           <Navbar.Brand>
-            <a href="#">Ickly</a>
+            <a href="/">Ickly</a>
           </Navbar.Brand>
           <Navbar.Toggle />
         </Navbar.Header>
         <Navbar.Collapse>
           <Nav pullRight>
-            <NavItem eventKey={1} href="#">About</NavItem>
-            <NavItem eventKey={2} href="#">Contact</NavItem>
+            <LinkContainer to="/about">
+              <NavItem eventKey={1} href="#">About</NavItem>
+            </LinkContainer>
+            <LinkContainer to="/contact">
+              <NavItem eventKey={2} href="#">Contact</NavItem>
+            </LinkContainer>
           </Nav>
         </Navbar.Collapse>
       </Navbar>

--- a/frontend/app/index.js
+++ b/frontend/app/index.js
@@ -6,6 +6,7 @@ import { render } from 'react-dom'
 import thunkMiddleware from 'redux-thunk'
 import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
+import { BrowserRouter as Router } from 'react-router-dom'
 import fetchBusiness from './actions/index'
 import fetchInspections from './actions/index'
 import rootReducer from './reducers/index'
@@ -20,9 +21,9 @@ const store = createStore(
 
 render(
   <Provider store={store}>
-    <div className='app-container'>
+    <Router>
       <App />
-    </div>
+    </Router>
   </Provider>,
   document.getElementById('react-app'))
 

--- a/frontend/test/about.spec.js
+++ b/frontend/test/about.spec.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import About from '../app/components/about';
+
+describe('<About />', () => {
+  it('should render the heading and description', () => {
+    const wrapper = shallow(<About />);
+    expect(wrapper.find('h1')).to.have.length(1)
+    expect(wrapper.find('p')).to.have.length(1)
+  });
+});

--- a/frontend/test/contact.spec.js
+++ b/frontend/test/contact.spec.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import Contact from '../app/components/contact';
+
+describe('<Contact />', () => {
+  it('should render a heading and description', () => {
+    const wrapper = shallow(<Contact />);
+    expect(wrapper.find('h1')).to.have.length(1)
+    expect(wrapper.find('li')).to.have.length(2)
+  });
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "react-dom": "15.5.4",
     "react-number-format": "^2.0.2",
     "react-redux": "^4.4.8",
+    "react-router-bootstrap": "^0.24.4",
+    "react-router-dom": "^4.2.2",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
     "styled-components": "^2.1.1"


### PR DESCRIPTION
Routes to about and contact should work. I just made some dummy components for them, and created a separate ticket to actually create those. The tests are also just basically boilerplate so i'll have tests to change when i make them. 

Unrelated to the rest of this PR, a past test on `BusinessSearch` is failing right now because of an update made to the TypeAhead library using something that is not automatically available in jsdom. Going to see if i can fix it.   ericgio/react-bootstrap-typeahead#185 