### PR TITLE
142 public api read only

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from models import Business, Inspection
+from api.models import Business, Inspection
 
 class BusinessSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from views import BusinessesViewSet, BusinessInspectionEdgeEndpoint
+
+from api.views import BusinessesViewSet, BusinessInspectionEdgeEndpoint
 
 router = routers.DefaultRouter()
 router.register(r'businesses', BusinessesViewSet)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,10 +1,9 @@
 from rest_framework import viewsets, filters
-from serializers import BusinessSerializer, InspectionSerializer
-from models import Business, Inspection
 
-class BaseEdgeViewSet(viewsets.ModelViewSet):
+from api.models import Business, Inspection
+from api.serializers import BusinessSerializer, InspectionSerializer
 
-    allowed_methods = ['GET', 'POST', 'PATCH', 'DELETE']
+class BaseEdgeViewSet(viewsets.ReadOnlyModelViewSet):
 
     def __init__(self, *args, **kwargs):
         super(BaseEdgeViewSet, self).__init__(*args, **kwargs)
@@ -18,7 +17,7 @@ class BaseEdgeViewSet(viewsets.ModelViewSet):
         parent_id = self.kwargs['parent_id']
         return self.queryset.filter(**{self.parent_field: parent_id})
 
-class BusinessesViewSet(viewsets.ModelViewSet):
+class BusinessesViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Business.objects.all()
     serializer_class = BusinessSerializer
     filter_backends = (filters.SearchFilter,)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ gunicorn==19.7.1
 idna==2.7
 mock==2.0.0
 pbr==1.10.0
-psycopg2==2.6.2
+psycopg2==2.8.4
 py==1.4.31
 pytest==3.0.6
 pytest-django==3.1.2


### PR DESCRIPTION
resolves #142 

1. public api endpoints inherit from `ReadOnlyModelViewSet` instead of `ModelViewSet` so they are read only. 
2. updates imports and psycopg2 to resolve errors when using python3 
